### PR TITLE
Bump Node-RED to 4.1.1

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/nodered/node-red:4.1.0
+FROM docker.io/nodered/node-red:4.1.1
 
 COPY ./src/settings.js /usr/src/node-red/settings.js
 


### PR DESCRIPTION
Automated bump of Node-RED to 4.1.1

Closes: #86