### PR TITLE
Bump Node-RED to 4.1.4

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/nodered/node-red:4.1.3
+FROM docker.io/nodered/node-red:4.1.4
 
 COPY ./src/settings.js /usr/src/node-red/settings.js
 


### PR DESCRIPTION
Automated bump of Node-RED to 4.1.4

Closes: #92