### PR TITLE
Bump Node-RED to 4.1.7

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/nodered/node-red:4.1.6
+FROM docker.io/nodered/node-red:4.1.7
 
 COPY ./src/settings.js /usr/src/node-red/settings.js
 


### PR DESCRIPTION
Automated bump of Node-RED to 4.1.7

Closes: #98